### PR TITLE
Remove CoordinateSystemCoefficient

### DIFF
--- a/docs/src/api-reference/models.md
+++ b/docs/src/api-reference/models.md
@@ -12,7 +12,6 @@ FieldCoefficient
 AnalyticalCoefficient
 SpectralTensorCoefficient
 SpatiallyHomogeneousDataField
-CoordinateSystemCoefficient
 evaluate_coefficient
 ```
 

--- a/docs/src/literate-howto/custom-stimulation-protocols.jl
+++ b/docs/src/literate-howto/custom-stimulation-protocols.jl
@@ -29,7 +29,7 @@ function (protocol::SimpleS1S2Protocol)(x,t)
 end
 
 # It is now possible to use the protocol as follows
-coordinate_system_coefficient = CoordinateSystemCoefficient(CartesianCoordinateSystem{3}()) # Or some cardiac coordinate system
+coordinate_system_coefficient = CartesianCoordinateSystem{3}() # Or some cardiac coordinate system
 stimulus_around_zero(x,t) = max(1.0-norm(x),0.0)
 stimulus_around_one(x,t)  = max(1.0-norm(x+one(x)),0.0)
 s1s2fun = SimpleS1S2Protocol(

--- a/docs/src/literate-tutorials/cm01_simple-active-stress.jl
+++ b/docs/src/literate-tutorials/cm01_simple-active-stress.jl
@@ -74,7 +74,7 @@ function calcium_profile_function(x::LVCoordinate,t)
 end
 calcium_field = AnalyticalCoefficient(
     calcium_profile_function,
-    CoordinateSystemCoefficient(coordinate_system),
+    coordinate_system,
 );
 
 # We will use for a very simple sarcomere model which is constant in the calcium concentration.

--- a/docs/src/literate-tutorials/cm03_3d0d-coupling.jl
+++ b/docs/src/literate-tutorials/cm03_3d0d-coupling.jl
@@ -276,7 +276,7 @@ function calcium_profile_function(x::LVCoordinate,t)
 end
 calcium_field = AnalyticalCoefficient(
     calcium_profile_function,
-    CoordinateSystemCoefficient(coordinate_system),
+    coordinate_system,
 )
 sarcomere_model = CaDrivenInternalSarcomereModel(ConstantStretchModel(), calcium_field)
 active_stress_model = ActiveStressModel(

--- a/docs/src/literate-tutorials/ep04_geselowitz-ecg.jl
+++ b/docs/src/literate-tutorials/ep04_geselowitz-ecg.jl
@@ -51,7 +51,7 @@ end
 protocol = Thunderbolt.AnalyticalTransmembraneStimulationProtocol(
     AnalyticalCoefficient(
         UniformEndocardialActivation(),
-        CoordinateSystemCoefficient(CartesianCoordinateSystem{3}())
+        CartesianCoordinateSystem{3}()
     ),
     [SVector((-Inf, Inf))],
 )

--- a/src/Thunderbolt.jl
+++ b/src/Thunderbolt.jl
@@ -103,7 +103,6 @@ export
     FieldCoefficient,
     AnalyticalCoefficient,
     FieldCoefficient,
-    CoordinateSystemCoefficient,
     SpectralTensorCoefficient,
     SpatiallyHomogeneousDataField,
     evaluate_coefficient,
@@ -197,6 +196,7 @@ export
     # Coordinate system
     LVCoordinateSystem,
     LVCoordinate,
+    BiVCoordinateSystem,
     BiVCoordinate,
     CartesianCoordinateSystem,
     compute_lv_coordinate_system,

--- a/src/modeling/core/coordinate_systems.jl
+++ b/src/modeling/core/coordinate_systems.jl
@@ -1,9 +1,11 @@
+abstract type CoordinateSystemCoefficient end
+
 """
     CartesianCoordinateSystem(mesh)
 
 Standard cartesian coordinate system.
 """
-struct CartesianCoordinateSystem{sdim,T}
+struct CartesianCoordinateSystem{sdim,T} <: CoordinateSystemCoefficient
     function CartesianCoordinateSystem{sdim}() where sdim
         return new{sdim,Float32}()
     end
@@ -27,7 +29,7 @@ getcoordinateinterpolation(cs::CartesianCoordinateSystem{sdim}, cell::CellType) 
 Simplified universal ventricular coordinate on LV only, containing the transmural, apicobasal and
 rotational coordinates. See [`compute_lv_coordinate_system`](@ref) to construct it.
 """
-struct LVCoordinateSystem{T, DH <: AbstractDofHandler, IPC}
+struct LVCoordinateSystem{T, DH <: AbstractDofHandler, IPC} <: CoordinateSystemCoefficient
     dh::DH
     ip_collection::IPC # TODO special dof handler with type stable interpolation
     u_transmural::Vector{T}
@@ -307,7 +309,7 @@ end
 Universal ventricular coordinate, containing the transmural, apicobasal, rotational 
 and transventricular coordinates.
 """
-struct BiVCoordinateSystem{T, DH <: Ferrite.AbstractDofHandler}
+struct BiVCoordinateSystem{T, DH <: Ferrite.AbstractDofHandler} <: CoordinateSystemCoefficient
     dh::DH
     u_transmural::Vector{T}
     u_apicobasal::Vector{T}

--- a/test/gpu/test_coefficients.jl
+++ b/test/gpu/test_coefficients.jl
@@ -103,8 +103,8 @@ import Tensors: Vec
 
     end
 
-    @testset "Cartesian CoordinateSystemCoefficient" begin
-        ccsc = CoordinateSystemCoefficient(CartesianCoordinateSystem(grid))
+    @testset "Cartesian Coordinate System" begin
+        ccsc = CartesianCoordinateSystem(grid)
         coeff_cache = setup_coefficient_cache(ccsc, qr, sdh)
         correct_vals = [Vec((-0.5f0,)), Vec((-0.45f0,)), Vec((0.5f0,)), Vec((0.55f0,))]
         Vals = correct_vals |> similar |> cu
@@ -118,7 +118,7 @@ import Tensors: Vec
     @testset "AnalyticalCoefficient" begin
         ac = AnalyticalCoefficient(
             (x, t) -> norm(x) + t,
-            CoordinateSystemCoefficient(CartesianCoordinateSystem(grid))
+            CartesianCoordinateSystem(grid)
         )
         coeff_cache = Thunderbolt.setup_coefficient_cache(ac, qr, sdh)
         correct_vals = [0.5f0, 0.45f0, 0.5f0, 0.55f0]

--- a/test/gpu/test_operators.jl
+++ b/test/gpu/test_operators.jl
@@ -10,7 +10,7 @@ cs = CartesianCoordinateSystem(grid)
 
 
 protocol = AnalyticalTransmembraneStimulationProtocol(
-                AnalyticalCoefficient((x,t) -> cos(2π * t) * exp(-norm(x)^2), CoordinateSystemCoefficient(cs)),
+                AnalyticalCoefficient((x,t) -> cos(2π * t) * exp(-norm(x)^2), cs),
                 [SVector((0.f0, 1.f0))]
             )
 

--- a/test/integration/test_electrophysiology.jl
+++ b/test/integration/test_electrophysiology.jl
@@ -25,7 +25,7 @@ using Thunderbolt
     end
 
     function solve_waveprop(mesh, coeff, subdomains, timestepper)
-        cs = CoordinateSystemCoefficient(CartesianCoordinateSystem(mesh))
+        cs = CartesianCoordinateSystem(mesh)
         model = MonodomainModel(
             ConstantCoefficient(1.0),
             ConstantCoefficient(1.0),

--- a/test/test_coefficients.jl
+++ b/test/test_coefficients.jl
@@ -54,8 +54,8 @@
         @test evaluate_coefficient(coeff_cache, cell_cache, qp2, 1.0) ≈ Vec((0.0,(0.1+1.0)/2.0-1.0))
     end
 
-    @testset "Cartesian CoordinateSystemCoefficient" begin
-        ccsc = CoordinateSystemCoefficient(CartesianCoordinateSystem(grid))
+    @testset "Cartesian Coordinate System" begin
+        ccsc = CartesianCoordinateSystem(grid)
         coeff_cache = Thunderbolt.setup_coefficient_cache(ccsc, qr, sdh)
         reinit!(cell_cache, 1)
         @test evaluate_coefficient(coeff_cache, cell_cache, qp1, 0.0) ≈ Vec((-0.5,))
@@ -72,7 +72,7 @@
     @testset "AnalyticalCoefficient" begin
         ac = AnalyticalCoefficient(
             (x,t) -> norm(x)+t,
-            CoordinateSystemCoefficient(CartesianCoordinateSystem(grid))
+            CartesianCoordinateSystem(grid),
         )
         coeff_cache = Thunderbolt.setup_coefficient_cache(ac, qr, sdh)
         reinit!(cell_cache, 1)

--- a/test/test_microstructures.jl
+++ b/test/test_microstructures.jl
@@ -6,7 +6,7 @@
 
     ring_cs = compute_midmyocardial_section_coordinate_system(ring_grid)
 
-    cartesian_coefficient = CoordinateSystemCoefficient(CartesianCoordinateSystem(ring_grid))
+    cartesian_coefficient = CartesianCoordinateSystem(ring_grid)
     qr = getquadraturerule(qr_collection, getcells(ring_grid, 1))
 
     dh = DofHandler(ring_grid)
@@ -17,8 +17,7 @@
     cs_cache = Thunderbolt.setup_coefficient_cache(cartesian_coefficient, qr, sdh)
 
     @testset "Midmyocardial coordinate system" begin
-        csc = CoordinateSystemCoefficient(ring_cs)
-        cache2 = Thunderbolt.setup_coefficient_cache(csc, qr, sdh)
+        cache2 = Thunderbolt.setup_coefficient_cache(ring_cs, qr, sdh)
         for cellcache in CellIterator(ring_cs.dh)
             for qp in QuadratureIterator(qr)
                 x = evaluate_coefficient(cs_cache, cellcache, qp, 0.0)

--- a/test/test_operators.jl
+++ b/test/test_operators.jl
@@ -82,7 +82,7 @@ using BlockArrays, SparseArrays
         @testset "Constant Cartesian" begin
             cs = CartesianCoordinateSystem(grid)
             protocol = AnalyticalTransmembraneStimulationProtocol(
-                AnalyticalCoefficient((x,t) -> 1.0, CoordinateSystemCoefficient(cs)),
+                AnalyticalCoefficient((x,t) -> 1.0, cs),
                 [SVector((0.0, 1.0))]
             )
 
@@ -108,7 +108,7 @@ using BlockArrays, SparseArrays
         @testset "Quadratic Cartesian" begin
             cs = CartesianCoordinateSystem(grid)
             protocol = AnalyticalTransmembraneStimulationProtocol(
-                AnalyticalCoefficient((x,t) -> norm(x)^2+1.0, CoordinateSystemCoefficient(cs)),
+                AnalyticalCoefficient((x,t) -> norm(x)^2+1.0, cs),
                 [SVector((0.0, 1.0))]
             )
 


### PR DESCRIPTION
CoordinateSystemCoefficient one was an overengineered abstraction. It is now just the supertype for the coordinate systems.