### PR TITLE
Transfer cellsets in hexahedralize

### DIFF
--- a/src/mesh/tools.jl
+++ b/src/mesh/tools.jl
@@ -362,6 +362,14 @@ function _hexahedralize(mgrid::SimpleMesh{3,<:Any,T}) where {T}
     !isempty(grid.vertexsets) && warn("Vertexsets are not transfered to new mesh!")
     # !isempty(grid.edgesets) && warn("Edgesets are not transfered to new mesh!")
 
+    new_cellsets = Dict{String, OrderedSet{Int}}()
+    for (setname, cellset) ∈ grid.cellsets
+        new_cellsets[setname] = OrderedSet{Int}()
+        for cellidx ∈ cellset
+            push!(new_cellsets[setname], ntuple(i -> cell_offsets[cellidx] + i, (cellidx == length(cell_offsets) ? length(new_cells) : cell_offsets[cellidx+1]) - cell_offsets[cellidx])...)
+        end
+    end
+
     new_facetsets = Dict{String, OrderedSet{FacetIndex}}()
     for (setname,facetset) ∈ grid.facetsets
         new_facetsets[setname] = OrderedSet{FacetIndex}()
@@ -371,7 +379,7 @@ function _hexahedralize(mgrid::SimpleMesh{3,<:Any,T}) where {T}
             end
         end
     end
-    return Grid(new_cells, [grid.nodes; new_edge_nodes; new_face_nodes; new_cell_nodes]; facetsets=new_facetsets, nodesets=deepcopy(grid.nodesets))
+    return Grid(new_cells, [grid.nodes; new_edge_nodes; new_face_nodes; new_cell_nodes]; cellsets = new_cellsets, facetsets=new_facetsets, nodesets=deepcopy(grid.nodesets))
 end
 
 function compute_minΔx(grid::Grid{dim, CT, DT}) where {dim, CT, DT}

--- a/test/test_mesh.jl
+++ b/test/test_mesh.jl
@@ -26,7 +26,10 @@
         # Triangle
     ]
         dim = Ferrite.getrefdim(element_type)
-        grid = generate_grid(element_type, ntuple(_ -> 3, dim))
+        grid = generate_grid(element_type, ntuple(_ -> 4, dim))
+        addcellset!(grid, "right_cells", x -> x[1] ≥ 0.0)
+        addcellset!(grid, "left_cells", x -> x[1] ≤ 0.0)
+
         if dim == 3
             grid_hex = Thunderbolt.hexahedralize(grid)
             @test all(typeof.(getcells(grid_hex)) .== Hexahedron) # Test if we really hit all elements
@@ -45,6 +48,12 @@
             @test getfacetset(grid_hex, "front") == getfacetset(grid_hex, "front_new")
             addfacetset!(grid_hex, "back_new", x -> x[2] ≈ 1.0)
             @test getfacetset(grid_hex, "back") == getfacetset(grid_hex, "back_new")
+
+            # Check for correct transfer of cellsets
+            addcellset!(grid_hex, "right_cells_new", x -> x[1] ≥ 0.0)
+            @test getcellset(grid_hex, "right_cells") == getcellset(grid_hex, "right_cells_new")
+            addcellset!(grid_hex, "left_cells_new", x -> x[1] ≤ 0.0)
+            @test getcellset(grid_hex, "left_cells") == getcellset(grid_hex, "left_cells_new")
         end
 
         if element_type == Hexahedron


### PR DESCRIPTION
Hexahedralize doesn't transfer cellsets and there's no warning about it unlike vertexsets.