### PR TITLE
Carry det(F0) through the prestressed pullback

### DIFF
--- a/src/modeling/solid/materials.jl
+++ b/src/modeling/solid/materials.jl
@@ -785,6 +785,11 @@ Models the stress formulated in the 1st Piola-Kirchhoff stress tensor based on a
 of the deformation gradient $$F = F_{\textrm{e}} F_{0}$$ where we compute $$P(F_{\textrm{e}}) = P(F F^{-1}_{0})$$.
 
 Please note that it is assumed that $$F^{-1}_{0}$$ is the quantity computed by `prestress_field`.
+
+The inner model's strain energy is taken per unit volume of the **intermediate** (stress-free)
+configuration, so the referential density is $$\\Psi(F) = \\det(F_0)\\, \\Psi^e(F F_0^{-1})$$ and the
+first Piola stress carries the $$\\det(F_0)$$ factor. For isochoric prestress this coincides with the
+per-reference-volume convention; for non-isochoric fields (e.g. kinematic growth) it does not.
 """
 struct PrestressedMechanicalModel{MM, FF} <: AbstractMaterialModel
     inner_model::MM
@@ -880,6 +885,12 @@ function prestressed_material_routine(
 )
     F₀inv = evaluate_coefficient(coefficient_cache.prestress_cache, geometry_cache, qp, time)
     Fᵉ = F ⋅ F₀inv
+    # The inner model's energy density is defined per unit volume of the *intermediate* (stress-free)
+    # configuration, so the referential density is Ψ(F) = J₀ Ψᵉ(F F₀⁻¹) with J₀ = det F₀ — and the
+    # stress and tangent inherit the factor: P = ∂Ψ/∂F = J₀ Pᵉ F₀⁻ᵀ (Coleman–Noll). For isochoric
+    # prestress (J₀ = 1) this is invisible; for grown states the reference stress is otherwise wrong
+    # by exactly J₀.
+    J₀ = 1 / det(F₀inv)
     ∂Ψᵉ∂Fᵉ, ∂²Ψᵉ∂Fᵉ² = material_routine(
         material_model.inner_model,
         Fᵉ,
@@ -890,12 +901,13 @@ function prestressed_material_routine(
         time,
     )
     Pᵉ = ∂Ψᵉ∂Fᵉ # Elastic PK1
-    P = Pᵉ ⋅ transpose(F₀inv) # Obtained by Coleman-Noll procedure
+    P = J₀ * Pᵉ ⋅ transpose(F₀inv)
     Aᵉ = ∂²Ψᵉ∂Fᵉ² # Elastic mixed modulus
     # TODO condense these steps into a single operation "A_imkn F_jm F_ln"
-    # Pull elastic modulus from intermediate to reference configuration
+    # Pull elastic modulus from intermediate to reference configuration; J₀ is constant in F, so the
+    # tangent simply scales.
     ∂Pᵉ∂F = Aᵉ ⋅ transpose(F₀inv)
-    ∂P∂F = dot_2_1t(∂Pᵉ∂F, F₀inv)
+    ∂P∂F = J₀ * dot_2_1t(∂Pᵉ∂F, F₀inv)
     return P, ∂P∂F
 end
 
@@ -971,7 +983,8 @@ function reduced_prestressed_material_routine(
         time,
     )
     Pᵉ = ∂Ψᵉ∂Fᵉ # Elastic PK1
-    P = Pᵉ ⋅ transpose(F₀inv) # Obtained by Coleman-Noll procedure
+    # Same J₀ = det F₀ pushforward as in `prestressed_material_routine` — see the derivation there.
+    P = (1 / det(F₀inv)) * Pᵉ ⋅ transpose(F₀inv)
     return P
 end
 setup_internal_cache(

--- a/test/test_prestress_pullback.jl
+++ b/test/test_prestress_pullback.jl
@@ -1,7 +1,13 @@
 using Test
 using Thunderbolt
-using Thunderbolt: material_routine, reduced_prestressed_material_routine, setup_coefficient_cache,
-    setup_internal_cache, QuadraturePoint, OrthotropicMicrostructure, ConstantCoefficient
+using Thunderbolt:
+    material_routine,
+    reduced_prestressed_material_routine,
+    setup_coefficient_cache,
+    setup_internal_cache,
+    QuadraturePoint,
+    OrthotropicMicrostructure,
+    ConstantCoefficient
 using Thunderbolt.Tensors
 import Ferrite
 
@@ -21,15 +27,15 @@ import Ferrite
     qr  = Ferrite.QuadratureRule{Ferrite.RefHexahedron}(2)
     cc  = Ferrite.CellCache(grid)
     Ferrite.reinit!(cc, 1)
-    qp  = QuadraturePoint(1, first(Ferrite.getpoints(qr)))
+    qp = QuadraturePoint(1, first(Ferrite.getpoints(qr)))
 
-    ms  = OrthotropicMicrostructure(Vec((1.0, 0.0, 0.0)), Vec((0.0, 1.0, 0.0)), Vec((0.0, 0.0, 1.0)))
+    ms = OrthotropicMicrostructure(Vec((1.0, 0.0, 0.0)), Vec((0.0, 1.0, 0.0)), Vec((0.0, 0.0, 1.0)))
     inner = PK1Model(HolzapfelOgden2009Model(), ConstantCoefficient(ms))
-    F = one(Tensor{2,3}) + Tensor{2,3}((0.05, 0.02, 0.0, -0.01, -0.03, 0.02, 0.01, 0.0, 0.04))
+    F = one(Tensor{2, 3}) + Tensor{2, 3}((0.05, 0.02, 0.0, -0.01, -0.03, 0.02, 0.01, 0.0, 0.04))
 
     # Non-isochoric F₀⁻¹ (det ≈ 0.969, the same field the integration tests use) and an isochoric
     # control, normalized so det = 1 exactly up to floating point.
-    F₀inv_aniso = Tensor{2,3}((1.1, 0.1, 0.0, 0.2, 0.9, 0.1, -0.1, 0.0, 1.0))
+    F₀inv_aniso = Tensor{2, 3}((1.1, 0.1, 0.0, 0.2, 0.9, 0.1, -0.1, 0.0, 1.0))
     F₀inv_iso   = F₀inv_aniso / cbrt(det(F₀inv_aniso))
 
     for F₀inv in (F₀inv_aniso, F₀inv_iso)
@@ -45,7 +51,8 @@ import Ferrite
         @test P ≈ P_ad
         @test A ≈ A_ad
 
-        P_red = reduced_prestressed_material_routine(model, F, coeff_cache, state_cache, cc, qp, 0.0)
+        P_red =
+            reduced_prestressed_material_routine(model, F, coeff_cache, state_cache, cc, qp, 0.0)
         @test P_red ≈ P_ad
     end
 end

--- a/test/test_prestress_pullback.jl
+++ b/test/test_prestress_pullback.jl
@@ -1,0 +1,51 @@
+using Test
+using Thunderbolt
+using Thunderbolt: material_routine, reduced_prestressed_material_routine, setup_coefficient_cache,
+    setup_internal_cache, QuadraturePoint, OrthotropicMicrostructure, ConstantCoefficient
+using Thunderbolt.Tensors
+import Ferrite
+
+# The prestressed pullback against automatic differentiation of its defining energy.
+#
+# Convention under test: the inner model's energy is per unit volume of the *intermediate*
+# (stress-free) configuration, so Ψ(F) = det(F₀)·Ψᵉ(F F₀⁻¹) and both P and the tangent carry the
+# det(F₀) factor. The AD reference below *is* that definition, so any convention drift in the
+# hand-derived pullback — the missing J₀ this test was written against, a transpose, an index
+# order — shows up as a mismatch rather than needing a hand-computed expected value.
+@testset "prestressed pullback matches AD of det(F₀)·Ψᵉ(F F₀⁻¹)" begin
+    grid = Ferrite.generate_grid(Ferrite.Hexahedron, (1, 1, 1))
+    dh = Ferrite.DofHandler(grid)
+    Ferrite.add!(dh, :d, Ferrite.Lagrange{Ferrite.RefHexahedron, 1}()^3)
+    Ferrite.close!(dh)
+    sdh = first(dh.subdofhandlers)
+    qr  = Ferrite.QuadratureRule{Ferrite.RefHexahedron}(2)
+    cc  = Ferrite.CellCache(grid)
+    Ferrite.reinit!(cc, 1)
+    qp  = QuadraturePoint(1, first(Ferrite.getpoints(qr)))
+
+    ms  = OrthotropicMicrostructure(Vec((1.0, 0.0, 0.0)), Vec((0.0, 1.0, 0.0)), Vec((0.0, 0.0, 1.0)))
+    inner = PK1Model(HolzapfelOgden2009Model(), ConstantCoefficient(ms))
+    F = one(Tensor{2,3}) + Tensor{2,3}((0.05, 0.02, 0.0, -0.01, -0.03, 0.02, 0.01, 0.0, 0.04))
+
+    # Non-isochoric F₀⁻¹ (det ≈ 0.969, the same field the integration tests use) and an isochoric
+    # control, normalized so det = 1 exactly up to floating point.
+    F₀inv_aniso = Tensor{2,3}((1.1, 0.1, 0.0, 0.2, 0.9, 0.1, -0.1, 0.0, 1.0))
+    F₀inv_iso   = F₀inv_aniso / cbrt(det(F₀inv_aniso))
+
+    for F₀inv in (F₀inv_aniso, F₀inv_iso)
+        model = PrestressedMechanicalModel(inner, ConstantCoefficient(F₀inv))
+        coeff_cache = setup_coefficient_cache(model, qr, sdh)
+        state_cache = setup_internal_cache(model, qr, sdh)
+
+        W(F_) = 1 / det(F₀inv) * Thunderbolt.Ψ(F_ ⋅ F₀inv, ms, HolzapfelOgden2009Model())
+        P_ad = Tensors.gradient(W, F)
+        A_ad = Tensors.hessian(W, F)
+
+        P, A = material_routine(model, F, coeff_cache, state_cache, cc, qp, 0.0)
+        @test P ≈ P_ad
+        @test A ≈ A_ad
+
+        P_red = reduced_prestressed_material_routine(model, F, coeff_cache, state_cache, cc, qp, 0.0)
+        @test P_red ≈ P_ad
+    end
+end


### PR DESCRIPTION
The inner model's energy density is defined per unit volume of the intermediate (stress-free) configuration, so the referential density is Psi(F) = det(F0) * Psi_e(F F0^-1) and both P and the tangent inherit the factor. Isochoric prestress is unaffected; grown (non-isochoric) states were previously wrong by exactly det(F0).

Verified against AD of the defining energy in both the full and reduced routines (test/test_prestress_pullback.jl); the existing integration assertions are qualitative and unaffected.

